### PR TITLE
Set screen resolution for Bootanimation

### DIFF
--- a/cm.mk
+++ b/cm.mk
@@ -10,6 +10,10 @@ $(call inherit-product, vendor/cm/config/nfc_enhanced.mk)
 # Inherit device configuration
 $(call inherit-product, device/samsung/slte/device_slte.mk)
 
+# Boot animation
+TARGET_SCREEN_HEIGHT := 1280
+TARGET_SCREEN_WIDTH := 720
+
 ## Device identifier. This must come after all inclusions
 PRODUCT_NAME := cm_slte
 PRODUCT_DEVICE := slte


### PR DESCRIPTION
Maybe it will fix Bootanimation resolution mismatch.

In vendor/cm/config/common_full_phone.mk -

ifeq ($(TARGET_SCREEN_WIDTH) $(TARGET_SCREEN_HEIGHT),$(space))
    PRODUCT_COPY_FILES += \
        vendor/cm/prebuilt/common/bootanimation/480.zip:system/media/bootanimation.zip
endif

In slte, we don't set Screen Resolution.
So we need to set [TARGET_SCREEN_WIDTH] and [TARGET_SCREEN_HEIGHT] in cm.mk.
